### PR TITLE
Remove outdated activesupport dependency

### DIFF
--- a/sms_ru.gemspec
+++ b/sms_ru.gemspec
@@ -17,9 +17,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 2.0.0'
 
-  spec.add_dependency 'activesupport', '~> 4.2.0'
   spec.add_dependency 'launchy', '~> 2.4'
-  spec.add_dependency 'webmock', '~> 1.20'
+  spec.add_dependency 'webmock', '~> 2.3'
 
   spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
This dependency brokes Rails 5 and Ruby 2.4 compatibility 